### PR TITLE
Set Stylix Firefox profile name

### DIFF
--- a/homeManager/additionalApps/firefox.nix
+++ b/homeManager/additionalApps/firefox.nix
@@ -35,6 +35,10 @@
 
 			};
 		};
-				
-	};	
+
+		stylix.targets.firefox.profileNames = [
+			"ethanPersonal"
+		];
+
+        };
 }

--- a/homeManager/additionalApps/firefox.nix
+++ b/homeManager/additionalApps/firefox.nix
@@ -10,19 +10,20 @@
 	config = lib.mkIf config.firefox.enable {
 		# Actual content of the module goes here:
 
+
+		stylix.targets.firefox.profileNames = [
+			"ethanPersonal"
+		];
+
 		programs.firefox = {
-
 			enable = true;
-
 			profiles.ethanPersonal = {
-
 				settings = {
 					"toolkit.legacyUserProfileCustomizations.stylesheets" = true;
 					"browser.fullscreen.autohide" = false;
 					"browser.bookmarks.visibility" = "always";
 					
 				};
-
 				userChrome = ''
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 					
@@ -32,13 +33,8 @@
 	visibility: visible !important;
 }
 				'';
-
 			};
 		};
-
-		stylix.targets.firefox.profileNames = [
-			"ethanPersonal"
-		];
-
-        };
+						
+	};	
 }

--- a/homeManager/additionalApps/firefox.nix
+++ b/homeManager/additionalApps/firefox.nix
@@ -9,8 +9,6 @@
 	
 	config = lib.mkIf config.firefox.enable {
 		# Actual content of the module goes here:
-
-
 		stylix.targets.firefox.profileNames = [
 			"ethanPersonal"
 		];


### PR DESCRIPTION
## Summary
- set the Stylix Firefox target to include the ethanPersonal profile so theming can be applied without warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e175574990832a9ccc94feac5ea425